### PR TITLE
[Fix] Resolve bug and update Makefile & README.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,14 @@
-PREFIX = /usr
+NAME = tzyfetch
+INSTALL_PATH = /usr/local/bin
 
 all:
 	@echo Supported commands: \'make install\' or \'make uninstall\'.
 
 install:
-	@mkdir -p $(DESTDIR)$(PREFIX)/bin
-	@cp -p tzyfetch.sh $(DESTDIR)$(PREFIX)/bin/tzyfetch
-	@chmod +x $(DESTDIR)$(PREFIX)/bin/tzyfetch
+	install -m 755 $(NAME).sh $(INSTALL_PATH)/$(NAME)
 
 uninstall:
-	@rm -rf $(DESTDIR)$(PREFIX)/bin/tzyfetch
+	rm -f $(INSTALL_PATH)/tzyfetch
+
+.PHONY: all install uninstall
+.SILENT: all install uninstall

--- a/README.md
+++ b/README.md
@@ -1,28 +1,63 @@
-# tzyfetch .8.
-tzyfetch is an extremely simple fetch utility, built for a single line output featuring a unique, three character distro logo.
+# **tzyfetch** .8.
+**tzyfetch** is an extremely simple fetch utility, built for a single line output featuring a unique, three character distro logo.
 
-## Install
+### **Install**
 
-### Make
-    git clone https://github.com/cappsyco/tzyfetch.git
+#### **Arch Linux Family**
+
+1. **Install via AUR:**
+	tzyfetch is available in the [AUR](https://aur.archlinux.org/packages/tzyfetch).
+	You can use your favorite AUR helper to install it. For example, with **yay**:
+    ```sh
+    yay -S tzyfetch
+    ```
+
+#### **Other Distros**
+
+1. **Clone the repository:**
+   ```sh
+   git clone https://github.com/cappsyco/tzyfetch.git
+   ```
+
+   or
+
+   ```sh
+   git clone git@github.com:cappsyco/tzyfetch.git
+   ```
+
+2. **Move to the repository directory:**
+    ```sh
     cd tzyfetch
-    make install
+    ```
 
-### Arch Linux family
-[tzyfetch lives happily in the AUR](https://aur.archlinux.org/packages/tzyfetch). Use your favourite method for installation, but yay will do the job nicely.
+3. **Run the installer script:**
+    ```sh
+    sudo make install
+    ```
 
-	yay tzyfetch
+### **Usage**
 
-### Other?
-I'm figuring that out currently.
+After installing, you can use the **tzyfetch** command as follows:
 
-## Use
+- **Displays the distro logo, name, and current system information:**
+	```sh
     tzyfetch
-Default behaviour will return the logo and name of your distro, plus system and session specific information.
-
-    tzyfetch -d pisilinux
+    ```
+- **Use *-d* or *--distro* to display the logo of a specific distro ID:**
+	```sh
+    tzyfetch -d ubuntu
     tzyfetch -distro freebsd
-Outputs the logo of the specified distro ID.
-
+    ```
+- **Outputs all distro logos and IDs recognized by tzyfetch**
+	```sh
     tzyfetch -d all
-Outputs every distro logo and ID that tzyfetch knows.
+    ```
+
+### **Uninstall**
+
+To uninstall **tzyfetch**:
+
+- **Run the uninstaller script:**
+    ```sh
+    sudo make uninstall
+    ```

--- a/tzyfetch.sh
+++ b/tzyfetch.sh
@@ -1,4 +1,4 @@
-3#!/bin/bash
+#!/bin/bash
 
 # Function to display help text
 Help()


### PR DESCRIPTION
1. Bug Fix:
    - Removed a stray character ('3') before the shebang (#!/bin/bash) in the script, which was preventing it from executing                 properly.

2. Makefile Updates:
    - Replaced the cp and chmod combination with install -m to simplify the installation process.
    - Modified the installation path to /usr/local/bin/, which is more commonly used for executable files.
    - Replaced the use of @ with .SILENT to suppress command output for a cleaner Makefile execution.
    - Removed undefined variable $(DESTDIR).
    - Reorganized the Makefile to improve clarity.

3. README.md Reorganization:
    - Reorganized the README.md to improve clarity and coherence, while keeping the basic structure intact.
    - Updated the installation instructions, usage examples, and other relevant sections to make the documentation more user-friendly.